### PR TITLE
限制contextMenus選項在特定網頁出現

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,23 +1,28 @@
+const BASE_AC_URL = 'https://lighthouse.alphacamp.co/'
+const TA_WORK_TIME_URL = `${BASE_AC_URL}console/contract_work_times`
+const ASSIGNMENTS_URL = `${BASE_AC_URL}console/answer_lists`
+
 const items = [
   {
     "id": "submitWorkingTime",
     "title": "Submit time now",
     "contexts": ["all"],
+    "documentUrlPatterns": [`${BASE_AC_URL}*`]
   },
   {
     "id": "showAccumulatedTime",
     "title": "Show accumulated TA working time",
     "contexts": ["all"],
+    "documentUrlPatterns": [TA_WORK_TIME_URL]
   },
-    {
+  {
     "id": "showUnresolvedAssignments",
     "title": "Show unresolved assignments",
     "contexts": ["all"],
+    "documentUrlPatterns": [ASSIGNMENTS_URL]
   }
 ]
 
-const TA_WORK_TIME_URL = 'https://lighthouse.alphacamp.co/console/contract_work_times'
-const ASSIGNMENTS_URL = 'https://lighthouse.alphacamp.co/console/answer_lists'
 
 chrome.runtime.onInstalled.addListener(() => {
   items.forEach(item => chrome.contextMenus.create(item))


### PR DESCRIPTION
#### 調整部分：
- 利用match patterns來限制context menus item出現的網域/網址，防止誤按、減少出現選項
- 三個功能的限制為：
  - Submit time now ：在lighthouse中才會出現
  - Show accumulated TA working time：個人時數表中才會出現
  - Show unresolved assignments：作業總覽中才會出現
