### PR TITLE
Fix/document url patterns for show unresolved assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Change log
 
-#### v0.5 (2021-08-10 by [tsungtingdu](https://github.com/tsungtingdu))
+#### v0.5 (2021-08-12 by [tsungtingdu](https://github.com/tsungtingdu))
 
 Fix url pattern for displaying "Show unresolved assignments" button
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Change log
+
+#### v0.5 (2021-08-10 by [tsungtingdu](https://github.com/tsungtingdu))
+
+Fix url pattern for displaying "Show unresolved assignments" button
+
 #### v0.4 (2021-08-11 by [TomatoSoup0126](https://github.com/TomatoSoup0126))
 
 Shortcut for inserting rank and tagging student

--- a/background.js
+++ b/background.js
@@ -19,7 +19,7 @@ const items = [
     "id": "showUnresolvedAssignments",
     "title": "Show unresolved assignments",
     "contexts": ["all"],
-    "documentUrlPatterns": [ASSIGNMENTS_URL]
+    "documentUrlPatterns": [`${ASSIGNMENTS_URL}*`]
   },
   {
     "id": "retrieveCachedInput",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AC TA Tool Helper",
-  "version": "0.4",
+  "version": "0.5",
   "description": "AC TA Tool Helper",
   "manifest_version": 2,
   "permissions": [


### PR DESCRIPTION
## design

fix #5 

## test

- [x] display "Show unresolved assignments" button in `https://lighthouse.alphacamp.co/console/answer_lists/*` pages