### PR TITLE
Improvement/批改捷徑改為選單形式並增加選項

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change log
 
+### v0.6 (2021-08-15)
+
+Improvement for rank shortcut (by [TomatoSoup0126](https://github.com/TomatoSoup0126))
+
 ### v0.5 (2021-08-12)
 
 - Fix url pattern for displaying "Show unresolved assignments" button (by [tsungtingdu](https://github.com/tsungtingdu))

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a Chrome extension that supports TA's work.
 2. Show accumulated TA working time: 加總時數表當前時數（只在時數表頁面有效）
 3. Show unresolved assignments: Highlight 尚未完成作業批改的課程（只在作業總覽頁面有效）
 4. Retrieve cached input: 呈現近期輸入的內容在新視窗當中。複製貼上至 Lighthouse editor 即可獲得原有內容與排版
-5. Shortcut for inserting rank and tagging student: 回覆區域新增捷徑按鈕，點擊後自動填入批改等第與標記學生
+5. Shortcut for inserting rank and tagging student: 回覆區域新增捷徑選單，點擊後自動填入批改等第與標記學生
 
 ## How to use
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AC TA Tool Helper",
-  "version": "0.5",
+  "version": "0.6",
   "description": "AC TA Tool Helper",
   "manifest_version": 2,
   "permissions": [

--- a/src/background.js
+++ b/src/background.js
@@ -35,7 +35,7 @@ chrome.runtime.onInstalled.addListener(() => {
   chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (changeInfo.status === 'complete') {
       chrome.tabs.sendMessage(tabId, { target: 'cache' })
-      chrome.tabs.sendMessage(tabId, { target: 'createShortcutBtn' })
+      chrome.tabs.sendMessage(tabId, { target: 'createRankShortcut' })
     }
   })
 })

--- a/src/main.js
+++ b/src/main.js
@@ -81,35 +81,50 @@ chrome.runtime.onMessage.addListener(message => {
       return initCache()
     case 'retrieveCachedInput':
       return retrieveCachedInput()
-    case 'createShortcutBtn':
-      return createShortcutBtn()
+    case 'createRankShortcut':
+      return createRankShortcut()
   }
 })
 
-function createShortcutBtn () {
+// for rank shortcut
+const rankList = [
+  'Try harder',
+  'Meet expectations',
+  'Exceed expectations',
+  'Good',
+  'Excellent'
+]
+
+function createRankShortcut () {
   // 限制在TA reviews頁面使用此功能，submissions結構不一樣
   if (!window.location.href.includes('ta_reviews/user_answers')) return
   const body = document.querySelector('body')
   body.addEventListener('click', e => {
     const actionsBlocks = document.querySelectorAll('.editor-actions')
     actionsBlocks.forEach((actionsBlock, index) => {
-      // 展開reply input且只有submit & cancel才插入按鈕
+      // 展開reply input且只有submit & cancel才插入選單
       if (actionsBlock !== null && e.target.className === 'reply' && actionsBlock.childElementCount === 2) {
-        appendElement(actionsBlock, 'Meet expectations', 'btn btn-primary', `meet-expectations-${index}`)
-        appendElement(actionsBlock, 'Try harder', 'btn btn-primary', `try-harder-${index}`)
+        appendShortcutSelect(actionsBlock, `shortcut-select-${index}`)
       }
     })
-    if (e.target.id.includes('meet-expectations')) postMessage(e.target.id, 'Meet expectations')
-    if (e.target.id.includes('try-harder')) postMessage(e.target.id, 'Try harder')
+  })
+  body.addEventListener('change', e => {
+    if (rankList.includes(e.target.value)) {
+      postMessage(e.target.id, e.target.value)
+    }
   })
 }
 
-function appendElement (appendDom, text, customClass, id) {
-  const div = document.createElement('div')
-  div.innerText = text
-  div.className = customClass
-  div.setAttribute('id', id)
-  appendDom.prepend(div)
+function appendShortcutSelect (appendDom, id) {
+  const select = document.createElement('select')
+  select.innerHTML = `
+    <option value="">-- Quick insert --</option>
+  `
+  rankList.forEach(rank => {
+    select.innerHTML += `<option value="${rank}">${rank}</option>`
+  })
+  select.setAttribute('id', id)
+  appendDom.prepend(select)
 }
 
 function postMessage (id, message) {

--- a/src/main.js
+++ b/src/main.js
@@ -109,8 +109,9 @@ function createRankShortcut () {
     })
   })
   body.addEventListener('change', e => {
-    if (rankList.includes(e.target.value)) {
-      postMessage(e.target.id, e.target.value)
+    const { target: { id, value } } = e
+    if (rankList.includes(value)) {
+      postMessage(id, value)
     }
   })
 }


### PR DESCRIPTION
#9 新增 Exceed expectations 按鈕

#### 修改部分：
- 原有批改捷徑按鈕改用下拉選單取代
- 點擊選項後的行為比照原有功能
- 選項擴充為五個選項，可涵蓋個學期批改等第
  - Try harder
  - Meet expectations
  - Exceed expectations
  - Good
  - Excellent

![截圖 2021-08-15 下午5 57 14](https://user-images.githubusercontent.com/49901777/129474811-8cdde8c9-4656-44cc-b105-1972fd9b3b29.png)
