### PR TITLE
feature/批改捷徑連動選擇批改總分

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -167,6 +167,7 @@ function createRankShortcut () {
     const { target: { id, value } } = e
     if (rankList.includes(value)) {
       postMessage(id, value)
+      handleScoreSelector(value)
     }
   })
 }
@@ -199,4 +200,25 @@ function getStudentLink () {
   const id = nameDom.firstChild.href.split('/').pop()
   const name = nameDom.firstChild.innerText
   return `<a href="/users/${id}?m=1">@${name}</a>`
+}
+
+function handleScoreSelector (value) {
+  document.getElementById('answer_list_score').value = mapRankToScore(value)
+}
+
+function mapRankToScore (value) {
+  switch (value) {
+    case 'Try harder':
+      return 3
+    case 'Meet expectations':
+      return 2
+    case 'Exceed expectations':
+      return 1
+    case 'Good':
+      return 2
+    case 'Excellent':
+      return 1
+    default:
+      break
+  }
 }


### PR DESCRIPTION
#24 Select "Assignment Overall Score" when we insert grading into editor

####新增功能：
- 使用批改捷徑插入等地與標記學生時，連動切換該份作業的批改總分選項(Assignment Overall Score)
- 一份作業若有複數等第(Q1、Q2、Q3...)，最後批改總分實際上可能會參酌所有等地來修改，但因狀況較複雜，目前僅讓批改總分會不斷被最後的插入成績所覆蓋

![image](https://user-images.githubusercontent.com/49901777/130323224-fe50a33a-0810-4743-94bb-a4181e011c84.png)
