### PR TITLE
improvement/課程頁面標記功能、批改選項調整

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -34,6 +34,12 @@ chrome.webNavigation.onCompleted.addListener(({ tabId }) => {
 })
 
 chrome.webNavigation.onCompleted.addListener(({ tabId }) => {
+  chrome.tabs.sendMessage(tabId, { target: 'createQuestionerShortcut' })
+}, {
+  url: [{ hostSuffix: BASE_AC_URL_SUFFIX, pathContains: 'units' }]
+})
+
+chrome.webNavigation.onCompleted.addListener(({ tabId }) => {
   chrome.tabs.sendMessage(tabId, { target: 'cache' })
 }, {
   url: [{ hostSuffix: BASE_AC_URL_SUFFIX }]

--- a/src/main.js
+++ b/src/main.js
@@ -141,7 +141,8 @@ function createSwitchUnresolvedButton () {
 const rankList = [
   'Try harder',
   'Meet expectations',
-  'Exceed expectations'
+  'Exceed expectations',
+  'Tag student'
 ]
 
 // flag for avoid adding EventListener twice in createRankShortcut
@@ -194,7 +195,12 @@ function postMessage (id, message) {
     const div = document.createElement('div')
     editor.appendChild(div)
   }
-  editor.firstChild.innerHTML += `${message} ${getStudentLink()}`
+  // tag學生不用加上等第
+  if (message === 'Tag student') {
+    editor.firstChild.innerHTML += `${getStudentLink()}`
+  } else {
+    editor.firstChild.innerHTML += `${message} ${getStudentLink()}`
+  }
 }
 
 function getStudentLink () {
@@ -216,6 +222,8 @@ function mapRankToScore (value) {
       return 2
     case 'Exceed expectations':
       return 1
+    case 'Tag student':
+      return 2
     default:
       break
   }

--- a/src/main.js
+++ b/src/main.js
@@ -172,7 +172,7 @@ function createRankShortcut () {
   body.addEventListener('change', e => {
     const { target: { id, value } } = e
     if (rankList.includes(value)) {
-      postMessage(id, value)
+      postMessage(value, getEditor(id))
       handleScoreSelector(value)
     }
   })
@@ -200,9 +200,7 @@ function createQuestionerShortcut () {
     const { target: { id } } = e
     // 找到所屬的ul parent
     const subject = e.target.closest('ul')
-    if (id.includes('shortcut-btn')) {
-      postQuestioner(id, subject)
-    }
+    if (id.includes('shortcut-btn')) postQuestioner(subject, getEditor(id))
   })
 }
 
@@ -226,7 +224,7 @@ function appendShortcutBtn (appendDom, id) {
   appendDom.prepend(btn)
 }
 
-function postMessage (id, message) {
+function getEditor (id) {
   // 從觸發的btn id往上找editor
   const editor = document.getElementById(id).parentNode.previousElementSibling.childNodes[3]
   // 沒value時需要先create div
@@ -234,34 +232,23 @@ function postMessage (id, message) {
     const div = document.createElement('div')
     editor.appendChild(div)
   }
+  return editor
+}
+
+function postMessage (message, editor) {
+  const target = document.querySelector('.name')
   // tag學生不用加上等第
-  if (message === 'Tag student') {
-    editor.firstChild.innerHTML += `${getStudentLink()}`
-  } else {
-    editor.firstChild.innerHTML += `${message} ${getStudentLink()}`
-  }
+  editor.firstChild.innerHTML += message === 'Tag student' ? `${getNameLink(target)}` : `${message} ${getNameLink(target)}`
 }
 
-function postQuestioner (id, subject) {
-  const editor = document.getElementById(id).parentNode.previousElementSibling.childNodes[3]
-  if (editor.firstChild === null) {
-    const div = document.createElement('div')
-    editor.appendChild(div)
-  }
-  editor.firstChild.innerHTML += `${getQuestionerLink(subject)}`
+function postQuestioner (subject, editor) {
+  const target = subject.getElementsByTagName('h3')[0].nextElementSibling.firstChild
+  editor.firstChild.innerHTML += `${getNameLink(target)}`
 }
 
-function getStudentLink () {
-  const nameDom = document.querySelector('.name')
-  const id = nameDom.firstChild.href.split('/').pop()
-  const name = nameDom.firstChild.innerText
-  return `<a href="/users/${id}?m=1">@${name}</a>`
-}
-
-function getQuestionerLink (subject) {
-  const nameDom = subject.getElementsByTagName('h3')[0].nextElementSibling.firstChild
-  const id = nameDom.firstChild.href.split('/').pop()
-  const name = nameDom.firstChild.innerText
+function getNameLink (target) {
+  const id = target.firstChild.href.split('/').pop()
+  const name = target.firstChild.innerText
   return `<a href="/users/${id}?m=1">@${name}</a>`
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -243,12 +243,19 @@ function getEditor (id) {
 function postMessage (message, editor) {
   const target = document.querySelector('.name')
   // tag學生不用加上等第
-  editor.firstChild.innerHTML += message === 'Tag student' ? `${getNameLink(target)}` : `${message} ${getNameLink(target)}`
+  const element = message === 'Tag student' ? `${getNameLink(target)}` : `${message} ${getNameLink(target)}`
+  insertToEditor(element, editor)
+  // editor.firstChild.innerHTML += message === 'Tag student' ? `${getNameLink(target)}` : `${message} ${getNameLink(target)}`
 }
 
 function postQuestioner (subject, editor) {
   const target = subject.getElementsByTagName('h3')[0].nextElementSibling.firstChild
-  editor.firstChild.innerHTML += `${getNameLink(target)}`
+  insertToEditor(getNameLink(target), editor)
+  // editor.firstChild.innerHTML += `${getNameLink(target)}`
+}
+
+function insertToEditor (element, editor) {
+  editor.firstChild.innerHTML += element
 }
 
 function getNameLink (target) {

--- a/src/main.js
+++ b/src/main.js
@@ -187,21 +187,26 @@ function createQuestionerShortcut () {
   isCreateQuestionerShortcutCalled = true
 
   body.addEventListener('click', e => {
-    const actionsBlocks = document.querySelectorAll('.editor-actions')
-    actionsBlocks.forEach((actionsBlock, index) => {
-      // 展開reply input且只有submit & cancel才插入選單
-      if (actionsBlock !== null && e.target.className === 'reply' && actionsBlock.childElementCount === 2) {
-        appendShortcutBtn(actionsBlock, `shortcut-btn-${index}`)
-      }
-    })
+    appendShortcutBtnInEditor(e)
+    getAndPostQuestioner(e)
   })
+}
 
-  body.addEventListener('click', e => {
-    const { target: { id } } = e
-    // 找到所屬的ul parent
-    const subject = e.target.closest('ul')
-    if (id.includes('shortcut-btn')) postQuestioner(subject, getEditor(id))
+function appendShortcutBtnInEditor (event) {
+  const actionsBlocks = document.querySelectorAll('.editor-actions')
+  actionsBlocks.forEach((actionsBlock, index) => {
+    // 展開reply input且只有submit & cancel才插入選單
+    if (actionsBlock !== null && event.target.className === 'reply' && actionsBlock.childElementCount === 2) {
+      appendShortcutBtn(actionsBlock, `shortcut-btn-${index}`)
+    }
   })
+}
+
+function getAndPostQuestioner (event) {
+  const { target: { id } } = event
+  // 找到所屬的ul parent
+  const subject = event.target.closest('ul')
+  if (id.includes('shortcut-btn')) postQuestioner(subject, getEditor(id))
 }
 
 function appendShortcutSelect (appendDom, id) {

--- a/src/main.js
+++ b/src/main.js
@@ -141,9 +141,7 @@ function createSwitchUnresolvedButton () {
 const rankList = [
   'Try harder',
   'Meet expectations',
-  'Exceed expectations',
-  'Good',
-  'Excellent'
+  'Exceed expectations'
 ]
 
 // flag for avoid adding EventListener twice in createRankShortcut
@@ -217,10 +215,6 @@ function mapRankToScore (value) {
     case 'Meet expectations':
       return 2
     case 'Exceed expectations':
-      return 1
-    case 'Good':
-      return 2
-    case 'Excellent':
       return 1
     default:
       break

--- a/src/main.js
+++ b/src/main.js
@@ -245,13 +245,11 @@ function postMessage (message, editor) {
   // tag學生不用加上等第
   const element = message === 'Tag student' ? `${getNameLink(target)}` : `${message} ${getNameLink(target)}`
   insertToEditor(element, editor)
-  // editor.firstChild.innerHTML += message === 'Tag student' ? `${getNameLink(target)}` : `${message} ${getNameLink(target)}`
 }
 
 function postQuestioner (subject, editor) {
   const target = subject.getElementsByTagName('h3')[0].nextElementSibling.firstChild
   insertToEditor(getNameLink(target), editor)
-  // editor.firstChild.innerHTML += `${getNameLink(target)}`
 }
 
 function insertToEditor (element, editor) {


### PR DESCRIPTION
#32 Q&A + ORID 作業 tag 功能

#### 新增功能：
- unit頁面的Questions、Comment tab的回覆區域增加"標記提問者"按鈕，可直接標記提問者
- 移除批改頁面快速選單的good、excellent選項
- 新增批改頁面快速選單的tag student選項

#### 修改部分
- 標記提問者與批改快速選單功能有部分雷同程式碼，抽取相同部分並重構快速選單功能

![截圖 2021-11-06 上午12 41 19](https://user-images.githubusercontent.com/49901777/140549954-ac310728-93f8-4c55-b409-92a867b332c5.png)
![截圖 2021-11-06 上午12 42 31](https://user-images.githubusercontent.com/49901777/140550217-54a7d786-a81e-4873-9ea1-f6143ce5c1cd.png)


