### PR TITLE
Fix/批改捷徑失效修正

### DIFF
--- a/src/modules/createRankShortcut.js
+++ b/src/modules/createRankShortcut.js
@@ -47,7 +47,14 @@ export default () => {
     if (rank) {
       const { name, value } = RANKS[rank]
       if (value !== RANKS.TAG_STUDENT.value) {
-        document.getElementById('answer_list_score').value = value
+        const radios = document.querySelector('.radio').querySelectorAll('input')
+        radios.forEach(radio => {
+          if (+radio.value === value) {
+            radio.checked = true
+          } else {
+            radio.checked = false
+          }
+        })
       }
 
       postMessage(name, getEditor(id))


### PR DESCRIPTION
#### 修改部分
- 因評分下拉選單改為radio形式，導致新增rank至text area後要同步下拉選單的value時出錯
- 修改該功能，使其能對應到radio樣式上

<img width="764" alt="image" src="https://user-images.githubusercontent.com/49901777/170161409-209cff75-0972-4d3d-9624-470da00d09c0.png">
