### PR TITLE
feat/jonathan/sticky toolbar

### DIFF
--- a/src/modules/createQuestionerShortcut.js
+++ b/src/modules/createQuestionerShortcut.js
@@ -1,4 +1,4 @@
-import { getEditor, getNameLink, insertToEditor } from '../utils/editorOperator'
+import { getEditor, getNameLink, insertToEditor, injectToolbarStickyCSS } from '../utils/editorOperator'
 
 let isCreateQuestionerShortcutCalled = false
 
@@ -7,6 +7,8 @@ export default () => {
   if (!window.location.href.includes('units')) return
   if (isCreateQuestionerShortcutCalled) return
   isCreateQuestionerShortcutCalled = true
+
+  injectToolbarStickyCSS()
 
   const body = document.querySelector('body')
 

--- a/src/modules/createRankShortcut.js
+++ b/src/modules/createRankShortcut.js
@@ -28,6 +28,8 @@ export default () => {
   if (isCreateRankShortcutCalled) return
   isCreateRankShortcutCalled = true
 
+  injectToolbarStickyCSS()
+
   const body = document.querySelector('body')
 
   body.addEventListener('click', e => {
@@ -80,4 +82,21 @@ function appendShortcutSelect (appendDom, id) {
     select.innerHTML += `<option value="${value}">${name}</option>`
   })
   appendDom.prepend(select)
+}
+
+function injectToolbarStickyCSS () {
+  const injectStyle = document.getElementById('helper-inject-css')
+  if (!injectStyle) {
+    const head = document.head || document.getElementsByTagName('head')[0]
+    const style = document.createElement('style')
+    style.id = 'helper-inject-css'
+    style.textContent = `
+      trix-toolbar {
+        position: sticky;
+        top: 65px;
+        z-index: 4;
+      }
+    `
+    head.appendChild(style)
+  }
 }

--- a/src/modules/createRankShortcut.js
+++ b/src/modules/createRankShortcut.js
@@ -1,4 +1,4 @@
-import { getEditor, getNameLink, insertToEditor } from '../utils/editorOperator'
+import { getEditor, getNameLink, insertToEditor, injectToolbarStickyCSS } from '../utils/editorOperator'
 
 const RANKS = {
   TRT_HARDER: {
@@ -82,21 +82,4 @@ function appendShortcutSelect (appendDom, id) {
     select.innerHTML += `<option value="${value}">${name}</option>`
   })
   appendDom.prepend(select)
-}
-
-function injectToolbarStickyCSS () {
-  const injectStyle = document.getElementById('helper-inject-css')
-  if (!injectStyle) {
-    const head = document.head || document.getElementsByTagName('head')[0]
-    const style = document.createElement('style')
-    style.id = 'helper-inject-css'
-    style.textContent = `
-      trix-toolbar {
-        position: sticky;
-        top: 65px;
-        z-index: 4;
-      }
-    `
-    head.appendChild(style)
-  }
 }

--- a/src/utils/editorOperator.js
+++ b/src/utils/editorOperator.js
@@ -19,4 +19,21 @@ function insertToEditor (element, editor) {
   editor.firstChild.innerHTML += element
 }
 
-export { getEditor, getNameLink, insertToEditor }
+function injectToolbarStickyCSS () {
+  const injectStyle = document.getElementById('helper-inject-css')
+  if (!injectStyle) {
+    const head = document.head || document.getElementsByTagName('head')[0]
+    const style = document.createElement('style')
+    style.id = 'helper-inject-css'
+    style.textContent = `
+      trix-toolbar {
+        position: sticky;
+        top: 65px;
+        z-index: 4;
+      }
+    `
+    head.appendChild(style)
+  }
+}
+
+export { getEditor, getNameLink, insertToEditor, injectToolbarStickyCSS }


### PR DESCRIPTION
批改作業時，若有較長篇幅的回覆內容且需要使用toolbar來修改樣式/插入連結，會需要來回滾動至text-area頂端才能點擊toolbar

#### 新增部分：
- inject css使toolbar position變為sticky，減少來回滾動的情況
- 此功能會在作業批改與QA頁面運作

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/49901777/186705873-d668acb5-bc54-40e1-95f0-15b7b318d8a0.png">
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/49901777/186706035-0c2f5c2f-9404-4ee7-839f-3d2d83a606aa.png">
<img width="999" alt="image" src="https://user-images.githubusercontent.com/49901777/187017342-3003e746-6939-4bd5-be9c-046e68718fa0.png">

