### PR TITLE
Feat/jonathan/Canvas用批改捷徑

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,11 @@
-import { BASE_AC_URL_SUFFIX, BASE_AC_URL, TA_WORK_TIME_URL, ROUTES } from './utils/constants'
+import {
+  BASE_AC_URL_SUFFIX,
+  BASE_AC_URL,
+  BASE_AC_CANVAS_URL_SUFFIX,
+  TA_WORK_TIME_URL,
+  ROUTES,
+  CANVAS_ROUTES
+} from './utils/constants'
 
 const items = [
   {
@@ -53,6 +60,12 @@ chrome.webNavigation.onCompleted.addListener(({ tabId }) => {
   chrome.tabs.sendMessage(tabId, { target: 'showIncome' })
 }, {
   url: [{ hostSuffix: BASE_AC_URL_SUFFIX, pathContains: ROUTES.TA_INCOMES }]
+})
+
+chrome.webNavigation.onCompleted.addListener(({ tabId }) => {
+  chrome.tabs.sendMessage(tabId, { target: 'createSpeedGraderShortcut' })
+}, {
+  url: [{ hostSuffix: BASE_AC_CANVAS_URL_SUFFIX, pathContains: CANVAS_ROUTES.SPEED_GRADER }]
 })
 
 chrome.contextMenus.onClicked.addListener(function (info, tab) {

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import showAccumulatedWorkingTime from './modules/showAccumulatedWorkingTime'
 import showIncome from './modules/showIncome'
 import createRankShortcut from './modules/createRankShortcut'
 import createQuestionerShortcut from './modules/createQuestionerShortcut'
+import createSpeedGraderShortcut from './modules/createSpeedGraderShortcut'
 
 chrome.runtime.onMessage.addListener(message => {
   switch (message.target) {
@@ -21,5 +22,7 @@ chrome.runtime.onMessage.addListener(message => {
       return showIncome()
     case 'createQuestionerShortcut':
       return createQuestionerShortcut()
+    case 'createSpeedGraderShortcut':
+      return createSpeedGraderShortcut()
   }
 })

--- a/src/modules/createRankShortcut.js
+++ b/src/modules/createRankShortcut.js
@@ -1,23 +1,5 @@
 import { getEditor, getNameLink, insertToEditor, injectToolbarStickyCSS } from '../utils/editorOperator'
-
-const RANKS = {
-  TRT_HARDER: {
-    name: 'Try Harder',
-    value: 3
-  },
-  MEET_EXPECTATIONS: {
-    name: 'Meet expectations',
-    value: 2
-  },
-  EXCEED_EXPECTATIONS: {
-    name: 'Exceed expectations',
-    value: 1
-  },
-  TAG_STUDENT: {
-    name: 'Tag student',
-    value: 0
-  }
-}
+import { RANKS } from '../utils/constants'
 
 // flag for avoid adding EventListener twice in createRankShortcut
 let isCreateRankShortcutCalled = false

--- a/src/modules/createSpeedGraderShortcut.js
+++ b/src/modules/createSpeedGraderShortcut.js
@@ -8,17 +8,19 @@ export default () => {
   isCreateRankShortcutCalled = true
 
   const body = document.querySelector('body')
-  const insertElement = document.querySelector('.ic-Action-header__Secondary')
+  const insertElement = document.querySelector('#speed_grader_comment_textarea_mount_point')
 
-  insertShortcutSelector(insertElement, 0)
+  insertShortcutSelector(insertElement, 'canvas-rank-shortcut')
 
   body.addEventListener('change', e => {
-    const { target: { value } } = e
-    const rank = Object.keys(RANKS).find(rank => RANKS[rank].value === Number(value))
+    const { target: { value, id } } = e
+    if (id === 'canvas-rank-shortcut' && value) {
+      const rank = Object.keys(RANKS).find(rank => RANKS[rank].value === Number(value))
 
-    if (rank) {
-      const { name } = RANKS[rank]
-      postMessage(name, getStudentName())
+      if (rank) {
+        const { name } = RANKS[rank]
+        postMessage(name, getStudentName())
+      }
     }
   })
 }
@@ -29,14 +31,14 @@ function insertShortcutSelector (appendDom, id) {
   select.innerHTML = `
     <option value="">-- Quick insert --</option>
   `
-  // avoid canvas common css
-  select.style.marginBottom = '0px'
+  select.style.marginTop = '10px'
+  select.style.width = '100%'
 
   Object.keys(RANKS).forEach(rank => {
     const { name, value } = RANKS[rank]
     select.innerHTML += `<option value="${value}">${name}</option>`
   })
-  appendDom.prepend(select)
+  appendDom.append(select)
 }
 
 function postMessage (message, studentName) {

--- a/src/modules/createSpeedGraderShortcut.js
+++ b/src/modules/createSpeedGraderShortcut.js
@@ -1,0 +1,57 @@
+import { RANKS } from '../utils/constants'
+
+// flag for avoid adding EventListener twice in createRankShortcut
+let isCreateRankShortcutCalled = false
+
+export default () => {
+  if (isCreateRankShortcutCalled) return
+  isCreateRankShortcutCalled = true
+
+  const body = document.querySelector('body')
+  const insertElement = document.querySelector('.ic-Action-header__Secondary')
+
+  insertShortcutSelector(insertElement, 0)
+
+  body.addEventListener('change', e => {
+    const { target: { value } } = e
+    const rank = Object.keys(RANKS).find(rank => RANKS[rank].value === Number(value))
+
+    if (rank) {
+      const { name } = RANKS[rank]
+      postMessage(name, getStudentName())
+    }
+  })
+}
+
+function insertShortcutSelector (appendDom, id) {
+  const select = document.createElement('select')
+  select.setAttribute('id', id)
+  select.innerHTML = `
+    <option value="">-- Quick insert --</option>
+  `
+  // avoid canvas common css
+  select.style.marginBottom = '0px'
+
+  Object.keys(RANKS).forEach(rank => {
+    const { name, value } = RANKS[rank]
+    select.innerHTML += `<option value="${value}">${name}</option>`
+  })
+  appendDom.prepend(select)
+}
+
+function postMessage (message, studentName) {
+  const insertText = message === 'Tag student' ? `@${studentName}\n` : `${message} @${studentName}\n`
+  insertToTextArea(insertText)
+}
+
+function getStudentName () {
+  const studentNameBlock = document.querySelector('.ui-selectmenu-status > .ui-selectmenu-item-header')
+  return studentNameBlock?.innerText || ''
+}
+
+function insertToTextArea (text) {
+  const textArea = document.querySelector('#speed_grader_comment_textarea')
+  if (textArea) {
+    textArea.value += text
+  }
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,19 +1,49 @@
 const BASE_AC_URL_SUFFIX = 'lighthouse.alphacamp.co'
 const BASE_AC_URL = `https://${BASE_AC_URL_SUFFIX}`
 
+const BASE_AC_CANVAS_URL_SUFFIX = 'canvas.alphacamp.co'
+const BASE_AC_CANVAS_URL = `https://${BASE_AC_CANVAS_URL_SUFFIX}`
+
 const ROUTES = {
   ASSIGNMENTS: 'console/answer_lists',
   TA_WORK_TIME: 'console/contract_work_times',
   TA_INCOMES: 'console/ta_incomes'
 }
 
+const CANVAS_ROUTES = {
+  SPEED_GRADER: 'gradebook/speed_grader'
+}
+
 const TA_WORK_TIME_URL = `${BASE_AC_URL}/${ROUTES.TA_WORK_TIME}`
 const ASSIGNMENTS_URL = `${BASE_AC_URL}/${ROUTES.ASSIGNMENTS}`
+
+const RANKS = {
+  TRT_HARDER: {
+    name: 'Try Harder',
+    value: 3
+  },
+  MEET_EXPECTATIONS: {
+    name: 'Meet expectations',
+    value: 2
+  },
+  EXCEED_EXPECTATIONS: {
+    name: 'Exceed expectations',
+    value: 1
+  },
+  TAG_STUDENT: {
+    name: 'Tag student',
+    value: 0
+  }
+}
 
 export {
   BASE_AC_URL_SUFFIX,
   BASE_AC_URL,
+  BASE_AC_CANVAS_URL_SUFFIX,
+  BASE_AC_CANVAS_URL,
   TA_WORK_TIME_URL,
   ASSIGNMENTS_URL,
-  ROUTES
+  ROUTES,
+  CANVAS_ROUTES,
+  RANKS
 }


### PR DESCRIPTION
因部分常數與邏輯可以與現有插件共用，嘗試直接擴充此插件功能來支援canvas，讓助教們不需要再安裝新插件也可以優化canvas上的批改體驗，先追加canvas用批改捷徑功能

#### 修改部分：
- 抽出RANK常數，讓lighthouse與canvas可共用此常數
- 新增canvas批改捷徑功能"createSpeedGraderShortcut"
  - 基本操作邏輯同lighthouse版，下拉選項選擇後插入對應字串至textarea中
  - 按照canvas調整介面插入位置、簡化tag學生部分(canvas本身沒有tag功能)
  - 沒有自動選擇等第功能(記得會直接觸發submit)

<img width="632" alt="image" src="https://github.com/tsungtingdu/ac-ta-tool-helper/assets/49901777/b8f64d5d-c8ff-44fb-9ef2-e8e9509f0adf">


